### PR TITLE
Handle nested dict elem within auxinfo

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -218,7 +218,15 @@ def parse_dist(filename):
     auxinfo = auxinfos[0]
     key = None
     value = None
-    for node in auxinfo.childNodes:
+    children = auxinfo.childNodes
+    # handle the possibility that keys from auxinfo may be nested
+    # within a 'dict' element
+    dict_nodes = [n for n in auxinfo.childNodes
+                  if n.nodeType == n.ELEMENT_NODE and
+                  n.tagName == 'dict']
+    if dict_nodes:
+        children = dict_nodes[0].childNodes
+    for node in children:
         if node.nodeType == node.ELEMENT_NODE and node.tagName == 'key':
             key = node.firstChild.wholeText
         if node.nodeType == node.ELEMENT_NODE and node.tagName == 'string':


### PR DESCRIPTION
Noticed this in the new 10.13.2 (iMac Pro?) update. Apple has an inconsistent way of laying out the keys in `auxinfo`. This should address the following error:

```
➜ sudo ./installinstallmacos.py 
Downloading https://swscan.apple.com/content/catalogs/others/index-10.13seed-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog...
Downloading http://swcdn.apple.com/content/downloads/51/44/091-52052/dsqmhvw2nghj6dh9mtqwvx7gp4ykc7k5lb/InstallAssistantAuto.smd...
Downloading https://swdist.apple.com/content/downloads/51/44/091-52052/dsqmhvw2nghj6dh9mtqwvx7gp4ykc7k5lb/091-52052.English.dist...
Downloading http://swcdn.apple.com/content/downloads/49/07/091-33271/a0p216ukywyxia77i36ujq0bq91ghcyyaf/InstallAssistantAuto.smd...
Downloading https://swdist.apple.com/content/downloads/49/07/091-33271/a0p216ukywyxia77i36ujq0bq91ghcyyaf/091-33271.English.dist...
 #    ProductID    Version    Build  Title
Traceback (most recent call last):
  File "./installinstallmacos.py", line 417, in <module>
    main()
  File "./installinstallmacos.py", line 359, in main
    product_info[product_id]['BUILD'],
KeyError: 'BUILD'
```