### PR TITLE
Add --displayonly and --build arguments to installinstallmacos.py

### DIFF
--- a/docs/createbootvolfromautonbi.md
+++ b/docs/createbootvolfromautonbi.md
@@ -1,0 +1,18 @@
+### createbootvolfromautonbi.py
+
+A tool to make bootable disk volumes from the output of autonbi. Especially
+useful to make bootable disks containing Imagr and the 'SIP-ignoring' kernel,
+which allows Imagr to run scripts that affect SIP state, set UAKEL options, and
+run the `startosinstall` component, all of which might otherwise require network
+booting from a NetInstall-style nbi.
+
+Imagr (https://github.com/grahamgilbert/imagr) is a nice tool for automating Mac setup workflows. It is/was originally designed to be run from a Netboot volume, especially one created with the AutoNBI tool (https://github.com/bruienne/autonbi/). When run from a Netboot image created this way, Imagr runs as root, and SIP is ignored, enabling Imagr to do many of the needed tasks around setting up a machine for initial use.
+
+But Netboot might not be available in your environment. And the new iMac Pro does not support Netboot. `createbootvolfromautonbi.py` allows you to create a bootable external drive (USB/Firewire/Thunderbolt) from the output of autonbi, and more specifically, the output of the `make nbi` Makefile target included with Imagr.
+
+This would allow you to create an external boot drive with Imagr that can do what you can do with Imagr from an AutoNBI image.
+
+#### Usage
+
+```./createbootvolfromautonbi.py --nbi /path/to/Imagr.nbi --volume /Volumes/SomeEmptyExternalHFSPlusVolume```
+

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -679,7 +679,7 @@ def main():
 
         elif args.current:
             # automatically select matching build ID if current option used
-            if os_build == product_info[product_id]['BUILD']:
+            if build_info[0] == product_info[product_id]['BUILD']:
                 answer = index+1
                 break
 
@@ -715,10 +715,10 @@ def main():
             print ('\n'
                    'Build %s is not available. '
                    'Run again without --current argument '
-                   'to select a valid build to download.\n' % os_build)
+                   'to select a valid build to download.\n' % build_info[0])
             exit(0)
         else:
-            print '\nBuild %s available. Downloading #%s...\n' % (os_build, answer)
+            print '\nBuild %s available. Downloading #%s...\n' % (build_info[0], answer)
     elif args.version:
         try:
             answer

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -60,7 +60,7 @@ def get_board_id():
         ioreg_output = subprocess.check_output(ioreg_cmd).splitlines()
         for line in ioreg_output:
             if 'board-id' in line:
-                board_id = line.split(" ")[-1]
+                board_id = line.split("<")[-1]
                 board_id = board_id[board_id.find('<"')+2:board_id.find('">')]
                 return board_id
     except subprocess.CalledProcessError, err:

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -390,7 +390,9 @@ def main():
                 answer = index+1
                 print '# %s chosen.' % answer
 
-    if not answer:
+    try:
+        answer
+    except NameError:
         answer = raw_input(
             '\nChoose a product to download (1-%s): ' % len(product_info))
         try:

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -650,7 +650,7 @@ def main():
             not_valid = 'Unsupported Model Identifier'
         elif board_id not in product_info[product_id]['BoardIDs'] and is_vm == False:
             not_valid = 'Unsupported Board ID'
-        elif get_latest_version(build_info[0],product_info[product_id]['version']) != build_info[0]:
+        elif get_latest_version(build_info[0],product_info[product_id]['version']) != product_info[product_id]['version']:
             not_valid = 'Unsupported macOS version'
         else:
             valid_build_found = True

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -100,6 +100,17 @@ def get_current_build():
         return None
 
 
+def get_seeding_program(sucatalog_url):
+    '''Returns a seeding program name based on the sucatalog_url'''
+    try:
+        seed_catalogs = plistlib.readPlist(SEED_CATALOGS_PLIST)
+        for key, value in seed_catalogs.items():
+            if sucatalog_url == value:
+                return key
+    except (OSError, ExpatError, AttributeError, KeyError):
+        return None
+
+
 def get_seed_catalog():
     '''Returns the developer seed sucatalog'''
     try:
@@ -135,7 +146,7 @@ def make_compressed_dmg(app_path, diskimagepath, volume_name):
 
     print ('Making read-only compressed disk image containing %s...'
            % os.path.basename(app_path))
-    cmd = ['/usr/bin/hdiutil', 'create', '-volname "%s"' % volume_name, '-fs', 'HFS+',
+    cmd = ['/usr/bin/hdiutil', 'create', '-volname', volume_name, '-fs', 'HFS+',
            '-srcfolder', app_path, diskimagepath]
     try:
         subprocess.check_call(cmd)

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -42,7 +42,7 @@ from distutils.version import LooseVersion
 
 DEFAULT_SUCATALOG = (
     'https://swscan.apple.com/content/catalogs/others/'
-    'index-10.13seed-10.13-10.12-10.11-10.10-10.9'
+    'index-10.14seed-10.14-10.13-10.12-10.11-10.10-10.9'
     '-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz')
 
 SEED_CATALOGS_PLIST = (

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -373,7 +373,7 @@ def get_unsupported_models(filename):
             if 'nonSupportedModels' in line:
                 unsupported_models = line.split(" ")[-1][:-1]
                 return unsupported_models
-            
+
 
 def download_and_parse_sucatalog(sucatalog, workdir, ignore_cache=False):
     '''Downloads and returns a parsed softwareupdate catalog'''
@@ -691,6 +691,9 @@ def main():
     # Output a plist of available updates and quit if list option chosen
     if args.list:
         plistlib.writePlist(pl, output_plist)
+        print ('\n'
+               'Valid seeding programs are: %s'
+               % ', '.join(get_seeding_programs()))
         exit(0)
 
     # check for validity of specified build if argument supplied

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -694,14 +694,25 @@ def main():
             exit(0)
         else:
             print '\nBuild %s available. Downloading #%s...\n' % (os_build, answer)
-    elif args.auto or args.version:
+    elif args.version:
         try:
             answer
         except NameError:
             print ('\n'
                    'Item # %s is not available. '
+                   'Run again without --version argument '
+                   'to select a valid build to download.\n' % args.version)
+            exit(0)
+        else:
+            print '\nBuild %s selected. Downloading #%s...\n' % (lowest_valid_build, answer)
+    elif args.auto:
+        try:
+            answer
+        except NameError:
+            print ('\n'
+                   'No valid version available. '
                    'Run again without --auto argument '
-                   'to select a valid build to download.\n' % answer)
+                   'to select a valid build to download.\n')
             exit(0)
         else:
             print '\nBuild %s selected. Downloading #%s...\n' % (lowest_valid_build, answer)

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -63,7 +63,7 @@ SEED_CATALOGS_PLIST = (
 
 def get_board_id():
     '''Gets the local system board ID'''
-    ioreg_cmd = ['ioreg', '-p', 'IODeviceTree', '-r', '-n', '/', '-d', '1']
+    ioreg_cmd = ['/usr/sbin/ioreg', '-p', 'IODeviceTree', '-r', '-n', '/', '-d', '1']
     try:
         ioreg_output = subprocess.check_output(ioreg_cmd).splitlines()
         for line in ioreg_output:

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -129,13 +129,13 @@ def make_sparse_image(volume_name, output_path):
         exit(-1)
 
 
-def make_compressed_dmg(app_path, diskimagepath):
+def make_compressed_dmg(app_path, diskimagepath, volume_name):
     """Returns path to newly-created compressed r/o disk image containing
     Install macOS.app"""
 
     print ('Making read-only compressed disk image containing %s...'
            % os.path.basename(app_path))
-    cmd = ['/usr/bin/hdiutil', 'create', '-fs', 'HFS+',
+    cmd = ['/usr/bin/hdiutil', 'create', '-volname "%s"' % volume_name, '-fs', 'HFS+',
            '-srcfolder', app_path, diskimagepath]
     try:
         subprocess.check_call(cmd)
@@ -408,6 +408,14 @@ def os_installer_product_info(catalog, workdir, ignore_cache=False):
     return product_info
 
 
+def get_lowest_version(current_item, lowest_item):
+    '''Compares versions between two values and returns the lowest value'''
+    if LooseVersion(current_item) < LooseVersion(lowest_item):
+        return current_item
+    else:
+        return lowest_item
+
+
 def replicate_product(catalog, product_id, workdir, ignore_cache=False):
     '''Downloads all the packages for a product'''
     product = catalog['Products'][product_id]
@@ -442,14 +450,6 @@ def find_installer_app(mountpoint):
         if item.endswith('.app'):
             return os.path.join(applications_dir, item)
     return None
-
-
-def get_lowest_version(current_item, lowest_item):
-    '''Compares versions between two values and returns the lowest value'''
-    if LooseVersion(current_item) < LooseVersion(lowest_item):
-        return current_item
-    else:
-        return lowest_item
 
 
 def main():
@@ -549,7 +549,7 @@ def main():
             not_valid
         )
 
-        # go through various options for automatically determining the answer
+        # go through various options for automatically determining the answer:
 
         # skip if build is not suitable for current device
         # and a validation parameter was chosen
@@ -692,7 +692,7 @@ def main():
                 os.unlink(compressed_diskimagepath)
             app_path = find_installer_app(mountpoint)
             if app_path:
-                make_compressed_dmg(app_path, compressed_diskimagepath)
+                make_compressed_dmg(app_path, compressed_diskimagepath, volname)
             # unmount sparseimage
             unmountdmg(mountpoint)
             # delete sparseimage since we don't need it any longer

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -535,7 +535,7 @@ def main():
     pl['result'] = []
 
     # display a menu of choices (some seed catalogs have multiple installers)
-    print '%2s  %-15s %-10s %-8s %-11s %-20s %s' % ('#', 'ProductID', 'Version',
+    print '%2s  %-15s %-10s %-8s %-11s %-30s %s' % ('#', 'ProductID', 'Version',
                                      'Build', 'Post Date', 'Title', 'Notes')
     for index, product_id in enumerate(product_info):
         not_valid = ''
@@ -546,7 +546,7 @@ def main():
         elif get_lowest_version(build_info[0],product_info[product_id]['version']) != build_info[0]:
             not_valid = 'Unsupported macOS version'
 
-        print '%2s  %-15s %-10s %-8s %-11s %-20s %s' % (
+        print '%2s  %-15s %-10s %-8s %-11s %-30s %s' % (
             index + 1,
             product_id,
             product_info[product_id]['version'],


### PR DESCRIPTION
Hi Greg

I've made a small amendment to `installinstallmacos.py` in order to allow non-interactive use. My use case is to have a wrapper script which automates the selection of the desired installer.

To achieve this I have added a `--displayonly` argument, which runs the script as far as the displayed output and then quits. 

My wrapper script then grabs a build number using filtering criteria (which could be different depending on what is required). In my case, I use (in bash):

```
output=$(sudo python ${workdir}/installinstallmacos.py --workdir /Library/Management/macOSInstaller --displayonly | grep macOS | grep -v Beta)
outputarray=($output)
build="${outputarray[3]}"
``` 

This filters out any beta versions. I haven't needed to do it with the currently available downloads, but I remember in the past there were forked production builds available. In this case additional logic would need to be added to the wrapper depending on which build was required; e.g. grab the older `ProductID` for the non-forked version.

Then, by adding a `--build` argument, I can directly run the script to completion as follows:

```
sudo python ${workdir}/installinstallmacos.py --workdir /Library/Management/macOSInstaller --build ${build}
```

These additions do not change existing functionality. Of course, Apple may change their nomenclature and wrapper scripts that utilise the new arguments could therefore fail in the future, which is why I kept that logic out of `installinstallmacos.py` itself.

I'm happy to maintain my own fork if this is not of interest to the community, but if it is, please feel free to go ahead and merge.

Cheers
Graham