### PR TITLE
Fix resume download by not using cache date.

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -239,9 +239,10 @@ def replicate_url(full_url,
     curl_cmd = ['/usr/bin/curl', options, '--create-dirs',
                 '-o', local_file_path]
     if not ignore_cache and os.path.exists(local_file_path):
-        curl_cmd.extend(['-z', local_file_path])
         if attempt_resume:
             curl_cmd.extend(['-C', '-'])
+        else:
+            curl_cmd.extend(['-z', local_file_path])
     curl_cmd.append(full_url)
     print("Downloading %s..." % full_url)
     try:


### PR DESCRIPTION
Do not use cache date if trying to resume download: if
the "If-Modified-Since:" HTTP header is present, Apple
servers ignores the Range: HTTP header.