### PR TITLE
--list and --productid options added

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -459,9 +459,6 @@ def find_installer_app(mountpoint):
 
 def main():
     '''Do the main thing here'''
-#     if os.getuid() != 0:
-#         sys.exit('This command requires root (to install packages), so please '
-#                  'run again with sudo or as root.')
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--seedprogram', default='',
@@ -509,6 +506,11 @@ def main():
             print('Could not find a default catalog url for this OS version.',
                   file=sys.stderr)
             exit(-1)
+
+    if args.list==False and os.getuid() != 0:
+        sys.exit('This command requires root (to install packages), so please '
+                 'run again with sudo or as root.')
+
 
     # download sucatalog and look for products that are for macOS installers
     catalog = download_and_parse_sucatalog(

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -506,7 +506,8 @@ def main():
             print('Could not find a default catalog url for this OS version.',
                   file=sys.stderr)
             exit(-1)
-
+            
+    #listing doesn't require root so we allow it.
     if args.list==False and os.getuid() != 0:
         sys.exit('This command requires root (to install packages), so please '
                  'run again with sudo or as root.')
@@ -523,11 +524,13 @@ def main():
               file=sys.stderr)
         exit(-1)
 
+    #if product id is specified, skip menu or plist. If it is invalid, we will catch it later
     if args.productid:
         product_id=args.productid    
     else:
+        #build up a list for outputing as a plist, or just print as we read in the lines.
         available_os={}
-        # display a menu of choices (some seed catalogs have multiple installers)
+        # display a menu of choices (some seed catalogs have multiple installers) if not plist output
         if args.list==False:
             print('%2s %12s %10s %8s %11s  %s'
                   % ('#', 'ProductID', 'Version', 'Build', 'Post Date', 'Title'))
@@ -550,7 +553,7 @@ def main():
                     post_date,
                     title
                 ))
-    
+        #when done, output plist if that is what is requested, then exit cleanly
         if args.list==True:
             print (plistlib.writePlistToString(available_os))
             exit(0)


### PR DESCRIPTION
Add in the following options:

--list : output just a list of OS's and exit in plist format.
--productid: select the productid from the list

moved check for uid 0 to after check for list option since root is not required for that.

changed all info messages to stderr since stdout is used for outputting plist. 