### PR TITLE
Move `os.getuid()` check

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -459,10 +459,6 @@ def find_installer_app(mountpoint):
 
 def main():
     '''Do the main thing here'''
-    if os.getuid() != 0:
-        sys.exit('This command requires root (to install packages), so please '
-                 'run again with sudo or as root.')
-
     parser = argparse.ArgumentParser()
     parser.add_argument('--seedprogram', default='',
                         help='Which Seed Program catalog to use. Valid values '
@@ -488,6 +484,10 @@ def main():
                         help='Ignore any previously cached files.')
     args = parser.parse_args()
 
+    if os.getuid() != 0:
+    sys.exit('This command requires root (to install packages), so please '
+             'run again with sudo or as root.')
+    
     if args.catalogurl:
         su_catalog_url = args.catalogurl
     elif args.seedprogram:


### PR DESCRIPTION
Facilitates using `-h/--help` without having to use `sudo`.