### PR TITLE
installmacos.py: install_product: set CM_BUILD

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -208,6 +208,9 @@ def unmountdmg(mountpoint):
 def install_product(dist_path, target_vol):
     '''Install a product to a target volume.
     Returns a boolean to indicate success or failure.'''
+    # set CM_BUILD env var to make Installer bypass eligibilty checks
+    # when installing packages (for machine-specific OS builds)
+    os.environ["CM_BUILD"] = "CM_BUILD"
     cmd = ['/usr/sbin/installer', '-pkg', dist_path, '-target', target_vol]
     try:
         subprocess.check_call(cmd)


### PR DESCRIPTION
Set CM_BUILD env var in install_product()

This makes it possible to install machine-specific OS builds on 'non-supported' hardware
for example, 10.14.4 (18E2034) on machines that aren't iMac19,1 or iMac19,2.