### PR TITLE
updated installinstallmacos.py for Big Sur beta

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -54,6 +54,8 @@ DEFAULT_SUCATALOGS = {
     '19': 'https://swscan.apple.com/content/catalogs/others/'
           'index-10.15-10.14-10.13-10.12-10.11-10.10-10.9'
           '-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog',
+    '20': 'https://swscan.apple.com/content/catalogs/others/'
+          'index-10.16seed-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9'
 }
 
 SEED_CATALOGS_PLIST = (


### PR DESCRIPTION
Program now parses the update server for Big Sur and allows you to download the installer properly.