### PR TITLE
Add check for running from current user directory and bail with warning

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -514,7 +514,7 @@ def main():
                 print('Running this script from %s may not work as expected. '
                     'If this does not run as expected, please run again from '
                     'somewhere else, such as /Users/Shared.'
-                % current_dir, file=sys.stderr)
+                    % current_dir, file=sys.stderr)
 
     if args.catalogurl:
         su_catalog_url = args.catalogurl

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -506,6 +506,10 @@ def main():
         sys.exit('This command requires root (to install packages), so please '
                  'run again with sudo or as root.')
 
+    if os.path.expanduser("~") in os.getcwd():
+        sys.exit('This command cannot be run from within your home directory, so please '
+        'run again from somewhere else, such as /Users/Shared')
+
     if args.catalogurl:
         su_catalog_url = args.catalogurl
     elif args.seedprogram:

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -511,8 +511,10 @@ def main():
         bad_dirs = ['Documents', 'Desktop', 'Downloads', 'Library']
         for bad_dir in bad_dirs:
             if bad_dir in current_dir:
-                print('Running this script from {} may not work as expected. If this does not run as expected, '
-                'please run again from somewhere else, such as /Users/Shared'.format(current_dir))
+                print('Running this script from %s may not work as expected. '
+                'If this does not run as expected, please run again from '
+                'somewhere else, such as /Users/Shared.'
+                % current_dir, file=sys.stderr)
 
     if args.catalogurl:
         su_catalog_url = args.catalogurl

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -510,11 +510,11 @@ def main():
     if os.path.expanduser("~") in current_dir:
         bad_dirs = ['Documents', 'Desktop', 'Downloads', 'Library']
         for bad_dir in bad_dirs:
-            if bad_dir in current_dir:
+            if bad_dir in os.path.split(this_dir):
                 print('Running this script from %s may not work as expected. '
-                    'If this does not run as expected, please run again from '
-                    'somewhere else, such as /Users/Shared.'
-                    % current_dir, file=sys.stderr)
+                      'If this does not run as expected, please run again from '
+                      'somewhere else, such as /Users/Shared.'
+                      % current_dir, file=sys.stderr)
 
     if args.catalogurl:
         su_catalog_url = args.catalogurl

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -511,8 +511,8 @@ def main():
         bad_dirs = ['Documents', 'Desktop', 'Downloads', 'Library']
         for bad_dir in bad_dirs:
             if bad_dir in current_dir:
-                sys.exit('This command cannot be run from within certain home directories, so please '
-                'run again from somewhere else, such as /Users/Shared')
+                print('Running this script from {} may not work as expected. If this does not run as expected, '
+                'please run again from somewhere else, such as /Users/Shared'.format(current_dir))
 
     if args.catalogurl:
         su_catalog_url = args.catalogurl

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -506,9 +506,13 @@ def main():
         sys.exit('This command requires root (to install packages), so please '
                  'run again with sudo or as root.')
 
-    if os.path.expanduser("~") in os.getcwd():
-        sys.exit('This command cannot be run from within your home directory, so please '
-        'run again from somewhere else, such as /Users/Shared')
+    current_dir = os.getcwd()
+    if os.path.expanduser("~") in current_dir:
+        bad_dirs = ['Documents', 'Desktop', 'Downloads', 'Library']
+        for bad_dir in bad_dirs:
+            if bad_dir in current_dir:
+                sys.exit('This command cannot be run from within certain home directories, so please '
+                'run again from somewhere else, such as /Users/Shared')
 
     if args.catalogurl:
         su_catalog_url = args.catalogurl

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -512,8 +512,8 @@ def main():
         for bad_dir in bad_dirs:
             if bad_dir in current_dir:
                 print('Running this script from %s may not work as expected. '
-                'If this does not run as expected, please run again from '
-                'somewhere else, such as /Users/Shared.'
+                    'If this does not run as expected, please run again from '
+                    'somewhere else, such as /Users/Shared.'
                 % current_dir, file=sys.stderr)
 
     if args.catalogurl:


### PR DESCRIPTION
This isn't perfect, but it'll help dumb people like me from running it in my home directory and wondering why it doesn't work 😄 

Run from my Desktop:
```
sudo ./installinstallmacos.py
Running this script from /Users/nate/Desktop may not work as expected. If this does not run as expected, Please run again from somewhere else, such as /Users/Shared
Downloading https://swscan.apple.com/content/catalogs/others/index-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog...
...
```

Run from ~/code/macadmin-scripts:

```
sudo ./installinstallmacos.py
Downloading https://swscan.apple.com/content/catalogs/others/index-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog...
...
```