### PR TITLE
Fix HTTP resume

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -283,9 +283,9 @@ def replicate_url(full_url,
     try:
         output = subprocess.check_output(curl_cmd)
     except subprocess.CalledProcessError as err:
-        if resumed and int(err.output) != 416:
-            # Ignore HTTP error 416 on resume - it indicates that the download
-            # is already complete
+        # Ignore HTTP error 416 on resume - it indicates that the download is
+        # already complete
+        if not resumed or (int(err.output) != 416):
             raise ReplicationError(err)
     return local_file_path
 

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -285,7 +285,7 @@ def replicate_url(full_url,
     except subprocess.CalledProcessError as err:
         # Ignore HTTP error 416 on resume - it indicates that the download is
         # already complete
-        if not resumed or (int(err.output) != 416):
+        if not resumed or not err.output.isdigit() or (int(err.output) != 416):
             raise ReplicationError(err)
     return local_file_path
 

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -264,29 +264,40 @@ def replicate_url(full_url,
         options = '-fL'
     else:
         options = '-sfL'
-    curl_cmd = ['/usr/bin/curl', options,
-                '--create-dirs',
-                '-o', local_file_path,
-                '-w', '%{http_code}']
-    if not full_url.endswith(".gz"):
-        # stupid hack for stupid Apple behavior where it sometimes returns
-        # compressed files even when not asked for
-        curl_cmd.append('--compressed')
-    resumed = False
-    if not ignore_cache and os.path.exists(local_file_path):
-        curl_cmd.extend(['-z', '-' + local_file_path])
-        if attempt_resume:
-            resumed = True
-            curl_cmd.extend(['-C', '-'])
-    curl_cmd.append(full_url)
-    print("Downloading %s..." % full_url)
-    try:
-        output = subprocess.check_output(curl_cmd)
-    except subprocess.CalledProcessError as err:
-        # Ignore HTTP error 416 on resume - it indicates that the download is
-        # already complete and the file is up-to-date.
-        if not resumed or not err.output.isdigit() or (int(err.output) != 416):
-            raise ReplicationError(err)
+    need_download = True
+    while need_download:
+        curl_cmd = ['/usr/bin/curl', options,
+                    '--create-dirs',
+                    '-o', local_file_path,
+                    '-w', '%{http_code}']
+        if not full_url.endswith(".gz"):
+            # stupid hack for stupid Apple behavior where it sometimes returns
+            # compressed files even when not asked for
+            curl_cmd.append('--compressed')
+        resumed = False
+        if not ignore_cache and os.path.exists(local_file_path):
+            if not attempt_resume:
+                curl_cmd.extend(['-z', local_file_path])
+            else:
+                resumed = True
+                curl_cmd.extend(['-z', '-' + local_file_path, '-C', '-'])
+        curl_cmd.append(full_url)
+        print("Downloading %s..." % full_url)
+        need_download = False
+        try:
+            output = subprocess.check_output(curl_cmd)
+        except subprocess.CalledProcessError as err:
+            if not resumed or not err.output.isdigit():
+                raise ReplicationError(err)
+            # HTTP error 416 on resume: the download is already complete and the
+            # file is up-to-date
+            # HTTP error 412 on resume: the file was updated server-side
+            if int(err.output) == 412:
+                print("Removing %s and retrying." % local_file_path)
+                os.unlink(local_file_path)
+                need_download = True
+            elif int(err.output) != 416:
+                raise ReplicationError(err)
     return local_file_path
 
 

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -272,7 +272,7 @@ def replicate_url(full_url,
         # compressed files even when not asked for
         curl_cmd.append('--compressed')
     if not ignore_cache and os.path.exists(local_file_path):
-        curl_cmd.extend(['-z', local_file_path])
+        curl_cmd.extend(['-z', '-' + local_file_path])
         if attempt_resume:
             curl_cmd.extend(['-C', '-'])
     curl_cmd.append(full_url)

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -284,7 +284,7 @@ def replicate_url(full_url,
         output = subprocess.check_output(curl_cmd)
     except subprocess.CalledProcessError as err:
         # Ignore HTTP error 416 on resume - it indicates that the download is
-        # already complete
+        # already complete and the file is up-to-date.
         if not resumed or not err.output.isdigit() or (int(err.output) != 416):
             raise ReplicationError(err)
     return local_file_path

--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -284,7 +284,8 @@ def replicate_url(full_url,
         output = subprocess.check_output(curl_cmd)
     except subprocess.CalledProcessError as err:
         if resumed and int(err.output) != 416:
-            # Ignore HTTP error 416 on resume - it indicates that the download is already complete
+            # Ignore HTTP error 416 on resume - it indicates that the download
+            # is already complete
             raise ReplicationError(err)
     return local_file_path
 


### PR DESCRIPTION
If you start the script, select a release, and interrupt the download, the transfer of the partially-downloaded file is not resumed with the script is restarted.

Here, I'm stopping a download with ^C:

```
Choose a product to download (1-14): 2
Downloading http://swcdn.apple.com/content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 25  475M   25  119M    0     0  9856k      0  0:00:49  0:00:12  0:00:37 9839k^CTraceback (most recent call last):
  File "installinstallmacos.py", line 633, in <module>
    main()
  File "installinstallmacos.py", line 582, in main
    catalog, product_id, args.workdir, ignore_cache=args.ignore_cache)
  File "installinstallmacos.py", line 463, in replicate_product
    attempt_resume=(not ignore_cache))
  File "installinstallmacos.py", line 282, in replicate_url
    subprocess.check_call(curl_cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 185, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 172, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1099, in wait
    pid, sts = _eintr_retry_call(os.waitpid, self.pid, 0)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 125, in _eintr_retry_call
    return func(*args)
KeyboardInterrupt
Craig-Davisons-Mac-mini-2:macOS crg$ find content/ -name BaseSystem.dmg -ls
22409155   263816 -rw-r--r--    1 root             staff            131301376 24 Jan 23:02 content//downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg
```

And, on restart:
```
Choose a product to download (1-14): 2
Downloading http://swcdn.apple.com/content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg...
** Resuming transfer from byte position 131301376
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
```

```
$ find content/ -name BaseSystem.dmg -ls
22409155   263816 -rw-r--r--    1 root             staff            131301376 24 Jan 23:02 content//downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg
```

We can see that curl didn't actually complete the download.

It looks like the script uses a command like `/usr/bin/curl -fL --create-dirs -o ./content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg --compressed -z ./content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg -C - http://swcdn.apple.com/content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg
` to download the file. Because `-z` is specified, the `If-Modified-Since` header is added. Because the file on the server side is older than the date in that header, the web server returns 304 and no file contents.

I tried running the curl command above with `-v` to illustrate this:
```
$ sudo /usr/bin/curl -v -fL --create-dirs -o ./content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg --compressed -z ./content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg -C - http://swcdn.apple.com/content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg
** Resuming transfer from byte position 131301376
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 8.253.151.116...
* TCP_NODELAY set
* Connected to swcdn.apple.com (8.253.151.116) port 80 (#0)
> GET /content/downloads/26/37/001-68446/r1dbqtmf3mtpikjnd04cq31p4jk91dceh8/BaseSystem.dmg HTTP/1.1
> Host: swcdn.apple.com
> Range: bytes=131301376-
> User-Agent: curl/7.64.1
> Accept: */*
> Accept-Encoding: deflate, gzip
> If-Modified-Since: Mon, 25 Jan 2021 06:02:19 GMT
> 
< HTTP/1.1 304 Not Modified
< Date: Sat, 16 Jan 2021 16:03:10 GMT
< Connection: keep-alive
< Cache-Control: public, max-age=2592000
< ETag: "76A63F2ADA06FD857D13821E2F958F76-8"
< Expires: Mon, 15 Feb 2021 16:03:10 GMT
< Last-Modified: Tue, 10 Nov 2020 23:21:44 GMT
< Server: ATS/8.1.1
< CDNUUID: 8cbd6117-5047-4bae-b7ef-e8ba0e7a8238-637869255
< X-Apple-MS-Content-Length: 498625205
< x-apple-request-uuid: 2fc47886-62e8-4d41-83f6-f1d126bf464d,2fc47886-62e8-4d41-83f6-f1d126bf464d
< X-iCloud-Content-Length: 498625205
< x-icloud-versionid: 7f544120-23ab-11eb-b1a9-248a078d3ec5
< X-Responding-Server: massilia_protocol_028:328000704:mr33p01if-zteh08013901.mr.if.apple.com:8083:20P53:f929716938ef
< X-Cache: HIT
< Age: 741773
< 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host swcdn.apple.com left intact
* Closing connection 0
```

The fix is to use `If-Unmodified-Since` instead of `If-modified-since`. This allows the resume to complete while ensuring the same copy of the file is being downloaded. If the server side file is newer, the download will fail with HTTP 412 (Precondition Failed), which is good because we don't want to resume an out-of-date download with new content at the end of the file.

All that needed to change was prefixing the filename specified in the `-z` option with a `-`. The curl man page says:
> Start the date expression with a dash (-) to make it request for
              a document that is older than the given date/time, default is  a
              document that is newer than the specified date/time.

