### PR TITLE
add monterey sucatalog

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -57,6 +57,9 @@ DEFAULT_SUCATALOGS = {
     '20': 'https://swscan.apple.com/content/catalogs/others/'
           'index-11-10.15-10.14-10.13-10.12-10.11-10.10-10.9'
           '-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog',
+    '21': 'https://swscan.apple.com/content/catalogs/others/'
+          'index-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9'
+          '-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog',
 }
 
 SEED_CATALOGS_PLIST = (


### PR DESCRIPTION
Oddly enough Apple is now using `10.16` instead of `11`.